### PR TITLE
Backport of fix(gradle-inspector): Optimize memory by caching dependency subtrees

### DIFF
--- a/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
+++ b/plugins/package-managers/gradle-plugin/src/main/kotlin/OrtModelBuilder.kt
@@ -54,6 +54,7 @@ internal class OrtModelBuilder : ToolingModelBuilder {
     private val logger = Logging.getLogger(OrtModelBuilder::class.java)
     private val errors = mutableListOf<String>()
     private val warnings = mutableListOf<String>()
+    private val globalDependencySubtrees = mutableMapOf<String, List<OrtDependency>>()
 
     override fun canBuild(modelName: String): Boolean = modelName == OrtDependencyTreeModel::class.java.name
 
@@ -202,7 +203,10 @@ internal class OrtModelBuilder : ToolingModelBuilder {
                                 warnings += message
                             }
 
-                            val dependencies = selectedComponent.dependencies.toOrtDependencies(poms, visited + id)
+                            // Check if we have scanned the dependencies of this subtree before, and if so, reuse them.
+                            val dependencies = globalDependencySubtrees.getOrPut(id.displayName) {
+                                selectedComponent.dependencies.toOrtDependencies(poms, visited + id)
+                            }
 
                             OrtDependencyImpl(
                                 groupId = id.group,


### PR DESCRIPTION
This PR backports the fix to version 34.0.0 (last JDK 17 based ORT version):

In large projects with many dependencies, the GradleInspector plugin often runs out of Java heap space, even when allocated 2 GB. This is due to all dependencies being stored in a large tree structure, which consumes a significant amount of memory.

This change introduces a caching mechanism for dependency subtrees of components. Instead of traversing and storing the entire dependency tree every time, the cache is checked first. If a subtree for a component already exists in the cache, a reference to this cached data is used, reducing memory consumption significantly.

Fixes #9220.

Signed-off-by: Wolfgang Klenk <wolfgang.klenk2@bosch.com>
(cherry picked from commit 9ccccf6b86b0f3aaf16add5067d8011b4511e33a)