### PR TITLE
Backport of feat(spdx): Add file level information to SPDX projects

### DIFF
--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.json
@@ -22,7 +22,7 @@
   "packages" : [ {
     "SPDXID" : "SPDXRef-Project-Maven-first-project-group-first-project-name-0.0.1",
     "copyrightText" : "NONE",
-    "downloadLocation" : "NONE",
+    "downloadLocation" : "https://github.com/path/first-project.git",
     "filesAnalyzed" : false,
     "homepage" : "first project's homepage",
     "licenseConcluded" : "NOASSERTION",

--- a/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
+++ b/plugins/reporters/spdx/src/funTest/assets/spdx-document-reporter-expected-output.spdx.yml
@@ -32,7 +32,7 @@ documentDescribes:
 packages:
 - SPDXID: "SPDXRef-Project-Maven-first-project-group-first-project-name-0.0.1"
   copyrightText: "NONE"
-  downloadLocation: "NONE"
+  downloadLocation: "https://github.com/path/first-project.git"
   filesAnalyzed: false
   homepage: "first project's homepage"
   licenseConcluded: "NOASSERTION"

--- a/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
+++ b/plugins/reporters/spdx/src/main/kotlin/Extensions.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
+import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.LicenseFinding
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Package
@@ -159,10 +160,10 @@ internal fun Package.toSpdxPackage(
         },
         copyrightText = licenseInfoResolver.getSpdxCopyrightText(id),
         downloadLocation = when (type) {
-            SpdxPackageType.PROJECT -> SpdxConstants.NONE
             SpdxPackageType.BINARY_PACKAGE -> binaryArtifact.url.nullOrBlankToSpdxNone()
             SpdxPackageType.SOURCE_PACKAGE -> sourceArtifact.url.nullOrBlankToSpdxNone()
             SpdxPackageType.VCS_PACKAGE -> vcsProcessed.toSpdxDownloadLocation(ortResult.getResolvedRevision(id))
+            SpdxPackageType.PROJECT -> vcs.url.nullOrBlankToSpdxNone()
         },
         externalRefs = if (type == SpdxPackageType.PROJECT) emptyList() else toSpdxExternalReferences(),
         filesAnalyzed = packageVerificationCode != null,
@@ -172,6 +173,7 @@ internal fun Package.toSpdxPackage(
             SpdxPackageType.SOURCE_PACKAGE -> SpdxConstants.NOASSERTION
             // Clear the concluded license as it might need to be different for the VCS location.
             SpdxPackageType.VCS_PACKAGE -> SpdxConstants.NOASSERTION
+            SpdxPackageType.PROJECT -> concludedLicense.nullOrBlankToSpdxNoassertionOrNone()
             else -> concludedLicense.nullOrBlankToSpdxNoassertionOrNone()
         },
         licenseDeclared = declaredLicensesProcessed.toSpdxDeclaredLicense(),
@@ -205,6 +207,7 @@ private fun OrtResult.getPackageVerificationCode(id: Identifier, type: SpdxPacka
     when (type) {
         SpdxPackageType.VCS_PACKAGE -> getFileListForId(id).takeIf { it?.provenance is RepositoryProvenance }
         SpdxPackageType.SOURCE_PACKAGE -> getFileListForId(id).takeIf { it?.provenance is ArtifactProvenance }
+        SpdxPackageType.PROJECT -> getFileListForId(id).takeIf { it?.provenance is KnownProvenance }
         else -> null
     }?.let { fileList ->
         calculatePackageVerificationCode(fileList.files.map { it.sha1 }.asSequence())


### PR DESCRIPTION
This is a backport of https://github.com/oss-review-toolkit/ort/pull/9646 to ORT version 34.x.x

In an SPDX report, the information of the project itself is converted to an SPDX package entity as it is done for external dependencies as well. However, this project entity does neither contain the attribute `licenseInfoFromFiles` nor does it contain file-level information even though the scanner found (and e.g. the web app report contains) licenses. Only detected copyright statements are included in the field `copyrightText`.

If the property `fileInformationEnabled` is set in the `SPDXDocumentReporter`, file-level information for the scanned project is included.

Co-authored-by: Kiko Fernandez-Reyes <kiko@erlang.org>
Co-authored-by: Daniel Kreck <daniel.kreck@collaboration-factory.de>

Signed-off-by: Kiko Fernandez-Reyes <kiko@erlang.org>

(cherry picked from commit 33b7a4f6784ad30674ef0348677595de153fb5ab)